### PR TITLE
Integrate recaptcha into suspicious checks and geoip actions/otherwises

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "umbress",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umbress",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Blazing fast ExpressJS anti-DDoS middleware ⚡",
   "main": "server/dist/index.js",
   "scripts": {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -220,9 +220,17 @@ export default function umbress(userOptions: UmbressOptions): (req: Req, res: Re
                     if (!options.advancedClientChallenging.enabled && options.geoipRule.action === 'check') {
                         return await sendInitialAutomated(initialOpts)
                     }
+
+                    if (!options.recaptcha.enabled && options.geoipRule.action === 'recaptcha') {
+                        return await sendCaptcha(initialOpts)
+                    }
                 } else {
                     if (!options.advancedClientChallenging.enabled && options.geoipRule.otherwise === 'check') {
                         return await sendInitialAutomated(initialOpts)
+                    }
+
+                    if (!options.recaptcha.enabled && options.geoipRule.otherwise === 'recaptcha') {
+                        return await sendCaptcha(initialOpts)
                     }
 
                     if (options.geoipRule.otherwise === 'block') {
@@ -238,6 +246,10 @@ export default function umbress(userOptions: UmbressOptions): (req: Req, res: Re
                     if (!options.advancedClientChallenging.enabled && options.geoipRule.action === 'check') {
                         return await sendInitialAutomated(initialOpts)
                     }
+
+                    if (!options.recaptcha.enabled && options.geoipRule.action === 'recaptcha') {
+                        return await sendCaptcha(initialOpts)
+                    }
                 } else {
                     if (options.advancedClientChallenging.enabled && options.geoipRule.otherwise === 'pass') {
                         bypassChecking = true
@@ -245,6 +257,10 @@ export default function umbress(userOptions: UmbressOptions): (req: Req, res: Re
 
                     if (!options.advancedClientChallenging.enabled && options.geoipRule.otherwise === 'check') {
                         return await sendInitialAutomated(initialOpts)
+                    }
+
+                    if (!options.recaptcha.enabled && options.geoipRule.otherwise === 'recaptcha') {
+                        return await sendCaptcha(initialOpts)
                     }
                 }
             }
@@ -505,10 +521,19 @@ export default function umbress(userOptions: UmbressOptions): (req: Req, res: Re
                 if (ipData === 'banned') {
                     if (options.checkSuspiciousAddresses.action === 'block') {
                         return res.status(403).end()
-                    } else if (options.checkSuspiciousAddresses.action === 'check') {
+                    }
+
+                    if (options.checkSuspiciousAddresses.action === 'check') {
                         return await sendInitialAutomated({
                             ...initialOpts,
-                            ...{ cookieTtl: options.checkSuspiciousAddresses.cookieTtl }
+                            ...{ automatedCookieTtl: options.checkSuspiciousAddresses.cookieTtl }
+                        })
+                    }
+
+                    if (options.checkSuspiciousAddresses.action === 'recaptcha') {
+                        return await sendCaptcha({
+                            ...initialOpts,
+                            ...{ recaptchaCookieTtl: options.checkSuspiciousAddresses.cookieTtl }
                         })
                     }
                 }

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -16,7 +16,7 @@ export interface UmbressOptions {
     checkSuspiciousAddresses?: {
         enabled: boolean
         token: string
-        action?: 'block' | 'check'
+        action?: 'block' | 'check' | 'recaptcha'
         banFor?: number
         cookieTtl?: 1
     }
@@ -45,7 +45,7 @@ export interface UmbressOptions {
     }
 }
 
-type geoipAction = 'block' | 'check' | 'pass'
+type geoipAction = 'block' | 'check' | 'pass' | 'recaptcha'
 
 export interface AbuseIPDBResponse {
     data: {


### PR DESCRIPTION
### Features 🎉
- Recaptcha is now available as action for `checkSuspiciousAddresses`, `geoipRule.action` and `geoipRule.otherwise`

### Bugs 🐛
- Fixed issue when `cookieTtl` option was ignored in `checkSuspiciousAddresses`.